### PR TITLE
Fix namespace inconsistencies in test imports

### DIFF
--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Calliostro\LastfmBundle\Tests\Integration;
 
-use Calliostro\Lastfm\LastfmClient;
+use Calliostro\LastFm\LastFmClient;
 use Calliostro\LastfmBundle\Tests\Fixtures\TestKernel;
 use GuzzleHttp\Exception\ClientException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class IntegrationTestCase extends TestCase
 {
-    protected LastfmClient $client;
+    protected LastFmClient $client;
 
     /**
      * Create a test kernel with the given configuration.

--- a/tests/Integration/PublicApiIntegrationTest.php
+++ b/tests/Integration/PublicApiIntegrationTest.php
@@ -70,7 +70,7 @@ final class PublicApiIntegrationTest extends IntegrationTestCase
 
         // Verify the client works without any rate limiting
         $client = $container->get('calliostro_lastfm.lastfm_client');
-        \assert($client instanceof \Calliostro\Lastfm\LastfmClient);
+        \assert($client instanceof \Calliostro\LastFm\LastFmClient);
 
         // Make requests - Bundle is ultra-lightweight with no built-in throttling
         $responses = [];
@@ -111,7 +111,7 @@ final class PublicApiIntegrationTest extends IntegrationTestCase
         $container = $kernel->getContainer();
 
         $client = $container->get('calliostro_lastfm.lastfm_client');
-        \assert($client instanceof \Calliostro\Lastfm\LastfmClient);
+        \assert($client instanceof \Calliostro\LastFm\LastFmClient);
         $this->client = $client;
     }
 }

--- a/tests/Unit/BundleIntegrationTest.php
+++ b/tests/Unit/BundleIntegrationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Calliostro\LastfmBundle\Tests\Unit;
 
-use Calliostro\Lastfm\LastfmClient;
+use Calliostro\LastFm\LastFmClient;
 use Calliostro\LastfmBundle\Tests\Fixtures\TestKernel;
 
 final class BundleIntegrationTest extends UnitTestCase

--- a/tests/Unit/BundleIntegrationTest.php
+++ b/tests/Unit/BundleIntegrationTest.php
@@ -13,7 +13,7 @@ final class BundleIntegrationTest extends UnitTestCase
     {
         $container = $this->bootKernelAndGetContainer();
 
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleWithAllConfigurationOptions(): void
@@ -25,7 +25,7 @@ final class BundleIntegrationTest extends UnitTestCase
         ];
 
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleWithAdvancedUserAgent(): void
@@ -34,28 +34,28 @@ final class BundleIntegrationTest extends UnitTestCase
             'user_agent' => 'AdvancedTestApp/2.0 +https://test.example.com',
         ];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleWithApiCredentialsOnly(): void
     {
         $config = ['api_key' => 'my_api_key', 'api_secret' => 'my_api_secret'];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleWithApiKeyOnly(): void
     {
         $config = ['api_key' => 'my_api_key_123'];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleWithCustomUserAgent(): void
     {
         $config = ['user_agent' => 'MyCustomApp/2.1.0 +http://example.com'];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testBundleServicesArePrivate(): void
@@ -68,7 +68,7 @@ final class BundleIntegrationTest extends UnitTestCase
 
         // Internal services should not be directly accessible in compiled container
         // (This is expected behavior in Symfony - internal services are private)
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testMultipleBundleInstancesIsolation(): void
@@ -87,8 +87,8 @@ final class BundleIntegrationTest extends UnitTestCase
         $client1 = $kernel1->getContainer()->get('calliostro_lastfm.lastfm_client');
         $client2 = $kernel2->getContainer()->get('calliostro_lastfm.lastfm_client');
 
-        $this->assertInstanceOf(LastfmClient::class, $client1);
-        $this->assertInstanceOf(LastfmClient::class, $client2);
+        $this->assertInstanceOf(LastFmClient::class, $client1);
+        $this->assertInstanceOf(LastFmClient::class, $client2);
 
         // Clients should be different instances
         $this->assertNotSame($client1, $client2);
@@ -109,7 +109,7 @@ final class BundleIntegrationTest extends UnitTestCase
 
         // Test that we can retrieve the main service
         $client = $container->get('calliostro_lastfm.lastfm_client');
-        $this->assertInstanceOf(LastfmClient::class, $client);
+        $this->assertInstanceOf(LastFmClient::class, $client);
 
         // Test service is singleton (same instance returned)
         $client2 = $container->get('calliostro_lastfm.lastfm_client');
@@ -132,7 +132,7 @@ final class BundleIntegrationTest extends UnitTestCase
 
         // Verify the client is created successfully with all parameters
         $client = $container->get('calliostro_lastfm.lastfm_client');
-        $this->assertInstanceOf(LastfmClient::class, $client);
+        $this->assertInstanceOf(LastFmClient::class, $client);
 
         $kernel->cleanupCache();
     }
@@ -157,8 +157,8 @@ final class BundleIntegrationTest extends UnitTestCase
         $prodClient = $prodKernel->getContainer()->get('calliostro_lastfm.lastfm_client');
         $testClient = $testKernel->getContainer()->get('calliostro_lastfm.lastfm_client');
 
-        $this->assertInstanceOf(LastfmClient::class, $prodClient);
-        $this->assertInstanceOf(LastfmClient::class, $testClient);
+        $this->assertInstanceOf(LastFmClient::class, $prodClient);
+        $this->assertInstanceOf(LastFmClient::class, $testClient);
         $this->assertNotSame($prodClient, $testClient);
 
         $prodKernel->cleanupCache();

--- a/tests/Unit/FunctionalTest.php
+++ b/tests/Unit/FunctionalTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Calliostro\LastfmBundle\Tests\Unit;
 
-use Calliostro\Lastfm\LastfmClient;
+use Calliostro\LastFm\LastFmClient;
 
 final class FunctionalTest extends UnitTestCase
 {

--- a/tests/Unit/FunctionalTest.php
+++ b/tests/Unit/FunctionalTest.php
@@ -11,7 +11,7 @@ final class FunctionalTest extends UnitTestCase
     public function testServiceWiring(): void
     {
         $container = $this->bootKernelAndGetContainer();
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testServiceWiringWithConfiguration(): void
@@ -19,31 +19,31 @@ final class FunctionalTest extends UnitTestCase
         $container = $this->bootKernelAndGetContainer(['user_agent' => 'test']);
 
         $LastfmClient = $container->get('calliostro_lastfm.lastfm_client');
-        $this->assertInstanceOf(LastfmClient::class, $LastfmClient);
+        $this->assertInstanceOf(LastFmClient::class, $LastfmClient);
 
         // Verify that the client is properly configured
         // The user agent configuration is handled internally by the bundle
         /* @noinspection PhpConditionAlreadyCheckedInspection */
-        $this->assertInstanceOf(LastfmClient::class, $LastfmClient);
+        $this->assertInstanceOf(LastFmClient::class, $LastfmClient);
     }
 
     public function testServiceWiringWithMinimalConfig(): void
     {
         $config = [];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testServiceWiringWithApiCredentials(): void
     {
         $config = ['api_key' => 'test_key_1234567890', 'api_secret' => 'test_secret_1234567890'];
         $container = $this->bootKernelAndGetContainer($config);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 
     public function testServiceWiringWithApiKeyOnly(): void
     {
         $container = $this->bootKernelAndGetContainer(['api_key' => 'test_key_1234567890']);
-        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastfmClient::class);
+        $this->assertServiceInstanceOf($container, 'calliostro_lastfm.lastfm_client', LastFmClient::class);
     }
 }


### PR DESCRIPTION
Fixes namespace inconsistencies where tests were importing Lastfm instead of LastFm to match the actual class names from calliostro/lastfm-client v2.0.0.

**Changes:**
- Updated namespace imports in test files from Calliostro\Lastfm\LastfmClient to Calliostro\LastFm\LastFmClient
- Applied CS fixer to update property type hints accordingly

**Files changed:**
- tests/Unit/FunctionalTest.php
- tests/Unit/BundleIntegrationTest.php  
- tests/Integration/IntegrationTestCase.php
- tests/Integration/PublicApiIntegrationTest.php

All CI checks passing.