### PR TITLE
Fix variable naming consistency

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,7 +130,7 @@ vendor/bin/phpunit tests/Integration/ --testdox
 
 The Symfony bundle provides:
 
-1. **Service Integration**: Seamless LastfmClient autowiring
+1. **Service Integration**: Seamless LastFmClient autowiring
 2. **Configuration Management**: YAML-based bundle configuration
 3. **Authentication Setup**: API key for read operations, API key + secret + session key for user operations (scrobbling, etc.)
 4. **Rate Limiting**: Optional throttling for API calls (5 requests/second per IP)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -174,7 +174,7 @@ Update all your service and controller code to use the new API methods.
 
 #### Service Not Found
 
-**Error**: Cannot autowire `LastfmClient`
+**Error**: Cannot autowire `LastFmClient`
 
 **Solution**: Make sure you've installed v2.0.0 and cleared cache:
 

--- a/tests/Unit/FunctionalTest.php
+++ b/tests/Unit/FunctionalTest.php
@@ -18,13 +18,13 @@ final class FunctionalTest extends UnitTestCase
     {
         $container = $this->bootKernelAndGetContainer(['user_agent' => 'test']);
 
-        $LastfmClient = $container->get('calliostro_lastfm.lastfm_client');
-        $this->assertInstanceOf(LastFmClient::class, $LastfmClient);
+        $lastFmClient = $container->get('calliostro_lastfm.lastfm_client');
+        $this->assertInstanceOf(LastFmClient::class, $lastFmClient);
 
         // Verify that the client is properly configured
         // The user agent configuration is handled internally by the bundle
         /* @noinspection PhpConditionAlreadyCheckedInspection */
-        $this->assertInstanceOf(LastFmClient::class, $LastfmClient);
+        $this->assertInstanceOf(LastFmClient::class, $lastFmClient);
     }
 
     public function testServiceWiringWithMinimalConfig(): void


### PR DESCRIPTION
Updates variable name from \\\ to \\\ to follow camelCase convention and match the updated class name.